### PR TITLE
docs: Align README with actual behavior and enhance clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A focused Laravel package that automatically generates Eloquent models and facto
 - Connection-based directory structure for multi-database projects
 - PSR-4 namespace validation and auto-correction
 - Compatible with PHP 8.2, 8.3, and 8.4
+- Compatible with Laravel 11.x
 
 ## Installation
 
@@ -53,6 +54,11 @@ return [
     | This value defines the default namespace for generated model classes.
     | You can override this on a per-model basis using the --namespace option.
     |
+    | Note: Generated relationship methods currently assume that related models
+    | reside in the `App\Models` namespace. If you customize `model_namespace`
+    | to something else, you may need to manually adjust the namespaces in the
+    | generated relationship methods.
+    |
     */
     'model_namespace' => 'App\\Models',
 
@@ -61,8 +67,12 @@ return [
     | Model Output Path
     |--------------------------------------------------------------------------
     |
-    | This value defines the default output path for generated model files.
-    | The path should be relative to the project root.
+    | This value defines the default base path for models and is used to
+    | determine their PHP namespace (e.g., `App\Models` if `model_path` is
+    | `app/Models`). By default, models will be placed in a
+    | `GeneratedModels/{connection_name}` subdirectory within this path
+    | (e.g., `app/Models/GeneratedModels/mysql`). This final output path can be
+    | fully customized using the `--directory` command-line option.
     |
     */
     'model_path' => 'app/Models',
@@ -72,8 +82,11 @@ return [
     | Factory Output Path
     |--------------------------------------------------------------------------
     |
-    | This value defines the default output path for generated factory files.
-    | The path should be relative to the project root.
+    | This value defines the default base output path for generated factory files.
+    | By default, factories will be placed in a
+    | `GeneratedFactories/{connection_name}` subdirectory within this path
+    | (e.g., `database/factories/GeneratedFactories/mysql`). This output path
+    | can be fully customized using the `--factory-directory` command-line option.
     |
     */
     'factory_path' => 'database/factories',
@@ -83,8 +96,9 @@ return [
     | Validation Rules
     |--------------------------------------------------------------------------
     |
-    | When true, the generator will add Laravel validation rules as PHPDoc
-    | annotations based on the column types and constraints.
+    | When true, the generator will add a `public static function rules(): array`
+    | method to the model class. This method contains Laravel validation rules
+    | based on the column types and constraints.
     |
     */
     'generate_validation_rules' => true,
@@ -104,7 +118,7 @@ Generate Eloquent models from your database schema:
 php artisan wink:generate-models
 
 # Common Options
---connection=mysql          # Specify database connection (default: sqlite)
+--connection=sqlite         # Specify database connection (default: sqlite)
 --directory=path/to/models  # Custom output directory for models
 --with-relationships       # Include relationships
 --with-rules              # Generate validation rules
@@ -114,8 +128,9 @@ php artisan wink:generate-models
 
 ### Directory Structure
 
-The package organizes generated files by connection name to prevent conflicts in multi-database projects:
+By default, the package organizes generated model files into a `GeneratedModels/{connection_name}` subdirectory. This subdirectory is created within the path defined by the `model_path` configuration option (which defaults to `app/Models`, resulting in a final default path like `app/Models/GeneratedModels/mysql`). A similar structure is used for factories based on the `factory_path` configuration.
 
+The typical default directory structure looks like this:
 ```
 app/
 ├── Models/
@@ -129,9 +144,11 @@ app/
             └── sqlite/      # Factories for SQLite connection
 ```
 
-Directory options accept either full paths or paths relative to the project root. If not specified:
-- Models: `app/Models/GeneratedModels/{connection}`
-- Factories: `database/factories/GeneratedFactories/{connection}`
+The `--directory` command-line option allows you to specify a custom output directory for models, completely overriding the default `{model_path}/GeneratedModels/{connection_name}` structure. Similarly, the `--factory-directory` option overrides the default for factories. These options accept either full paths or paths relative to the project root.
+
+If the relevant `--directory` or `--factory-directory` options are not specified, the defaults are:
+- Models: `{model_path}/GeneratedModels/{connection_name}` (e.g., `app/Models/GeneratedModels/mysql` using the default `model_path`)
+- Factories: `{factory_path}/GeneratedFactories/{connection_name}` (e.g., `database/factories/GeneratedFactories/mysql` using the default `factory_path`)
 
 ## Contributing
 


### PR DESCRIPTION
The README.md has been updated to accurately reflect the package's functionality and provide clearer explanations for you.

Key changes include:
- Corrected the default connection for `wink:generate-models` command to `sqlite`.
- Clarified that validation rules are generated as a static `rules()` method in the model, not as PHPDoc annotations.
- Detailed model and factory output path behaviors, explaining default paths (`app/Models/GeneratedModels/{connection}` and `database/factories/GeneratedFactories/{connection}`), the role of `model_path`/`factory_path` from config, and how `--directory`/`--factory-directory` options override these defaults.
- Added a note that generated relationship methods assume related models are in the `App\Models` namespace.
- Added Laravel 11.x compatibility information.
- Ensured the "Directory Structure" section is comprehensive and unambiguous.